### PR TITLE
Readme and package json update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Astro Web Component and CSS Library provides a starting point to begin devel
 - All components have been updated to [LitElement](https://lit-element.polymer-project.org) from Polymer
 - Updated documentation
 - [Storybook Component Sandbox](https://astro-components.netlify.com)
-- Merged [Astro Style Library](https://bitbucket.org/rocketcom/astro-styles/src/master/) in to Astro Components
+- Merged Astro Style Library in to Astro Components
 
 ## Download and Install for all Astro Web Components and Styles
 
@@ -26,7 +26,7 @@ cd astro
 Clone this repository
 
 ```
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
 Install NPM modules for this project
@@ -52,7 +52,7 @@ For projects that won’t use the Web Component Library you only need the conten
 Clone this repository
 
 ```
-git clone git@bitbucket.org:rocketcom/astro-components.git
+git@github.com:RocketCommunicationsInc/astro-components.git
 ```
 
 Copy the contents of the `static` directory (css, fonts, icons, img, favicon.ico) to your project directory. Create a link to the CSS.

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for buttons",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/__rux-template/README.md
+++ b/src/components/__rux-template/README.md
@@ -18,15 +18,15 @@ npm i --save @astrouxds/rux-template
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Template Web Component
 
@@ -57,7 +57,7 @@ Pass properties as attributes of the Astro Template custom element:
 
 ### 1. Include the Astro UXDS CSS file
 
-Latest release is available in [Astro UXDS Styles repo](https://bitbucket.org/rocketcom/astro-styles/src/master/).
+Latest release is available in the [static css directory](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static/css).
 
 ```xml
 <link rel="stylesheet" href="/your-project/path/astro.css" />
@@ -82,7 +82,7 @@ Configure the component using native HTML attributes or [BEM-style](http://getbe
 | `disabled`                | Boolean | `false` | No       | When set, what does this property do? |
 | `rux-template--attribute` | Class   | `''`    | No       | When set, what does this property do? |
 
-For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://bitbucket.org/rocketcom/astro-styles)
+For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://www.astrouxds.com/components/readme/#getting-started-with-html-%26-css)
 
 ## Revision History
 

--- a/src/components/__rux-template/README.md
+++ b/src/components/__rux-template/README.md
@@ -26,7 +26,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Template Web Component
 

--- a/src/components/rux-accordion/README.md
+++ b/src/components/rux-accordion/README.md
@@ -26,7 +26,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Accordion Web Component
 

--- a/src/components/rux-accordion/README.md
+++ b/src/components/rux-accordion/README.md
@@ -18,15 +18,15 @@ npm i --save @astrouxds/rux-accordion
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Accordion Web Component
 
@@ -68,7 +68,7 @@ The Boolean `open` attribute of the Astro UXDS Accordion custom element expands 
 
 ### 1. Include the Astro UXDS CSS file
 
-Latest release is available in [Astro UXDS Styles repo](https://bitbucket.org/rocketcom/astro-styles/src/master/).
+Latest release is available in the [static css directory](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static/css).
 
 ```xml
 <link rel="stylesheet" href="/your-project/path/astro.css" />
@@ -99,7 +99,7 @@ The Boolean `open` attribute of the`<details>` HTML element sets an accordion's 
 | --------- | ------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `open`    | Boolean | `false` | No       | While this attribute is present on the component, this accordion is open. By default, all accordions are closed. Multiple accordions can be open at the same time. |
 
-For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://bitbucket.org/rocketcom/astro-styles)
+For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://www.astrouxds.com/components/readme/#getting-started-with-html-%26-css)
 
 ## Revision History
 

--- a/src/components/rux-accordion/package.json
+++ b/src/components/rux-accordion/package.json
@@ -18,6 +18,7 @@
   "description": "Astro Web Component for accordions",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-accordion.js",
+  "module": "rux-accordion.js",
   "name": "@astrouxds/rux-accordion",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-accordion/package.json
+++ b/src/components/rux-accordion/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for accordions",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-button/README.md
+++ b/src/components/rux-button/README.md
@@ -18,15 +18,15 @@ npm i --save @astrouxds/rux-button
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Button Web Component
 
@@ -82,7 +82,7 @@ In this situation, you do not need to specify a size for the icon component -- t
 
 ### 1. Include the Astro UXDS CSS file
 
-Latest release is available in [Astro UXDS Styles repo](https://bitbucket.org/rocketcom/astro-styles/src/master/).
+Latest release is available in the [static css directory](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static/css).
 
 ```xml
 <link rel="stylesheet" href="/your-project/path/astro.css" />
@@ -132,7 +132,7 @@ Otherwise, wrap your icon SVG in an HTML element with the [BEM-style](http://get
 | `rux-button--icon`      | Class   | —       | No       | Displays an Astro icon matching this string to the left of the button text. Required when element also has the class `rux-button--icon-only`. For a [full list of available icons, see the Icons section in Astro UXDS Guidelines](https://astrouxds.com/ui-components/icons-and-symbols) Note: Astro UXDS icons are only available when using the Web Component usage pattern, which imports the `<rux-icon>` component. |
 | `rux-button--size`      | Class   | —       | No       | Displays the button as a `'small'` or `'large'` variant.                                                                                                                                                                                                                                                                                                                                                                  |
 
-For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://bitbucket.org/rocketcom/astro-styles)
+For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://www.astrouxds.com/components/readme/#getting-started-with-html-%26-css)
 
 ---
 

--- a/src/components/rux-button/README.md
+++ b/src/components/rux-button/README.md
@@ -26,7 +26,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Button Web Component
 

--- a/src/components/rux-button/package.json
+++ b/src/components/rux-button/package.json
@@ -20,6 +20,7 @@
   "description": "Astro Web Component for buttons",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-button.js",
+  "module": "rux-button.js",
   "name": "@astrouxds/rux-button",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-button/package.json
+++ b/src/components/rux-button/package.json
@@ -11,11 +11,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for buttons",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-clock/README.md
+++ b/src/components/rux-clock/README.md
@@ -18,15 +18,15 @@ npm i --save @astrouxds/rux-clock
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Clock Web Component
 

--- a/src/components/rux-clock/README.md
+++ b/src/components/rux-clock/README.md
@@ -26,7 +26,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Clock Web Component
 

--- a/src/components/rux-clock/package.json
+++ b/src/components/rux-clock/package.json
@@ -15,7 +15,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+		"url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
 	},
 	"description": "Astro Web Component for mission clock",
 	"license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-clock/package.json
+++ b/src/components/rux-clock/package.json
@@ -20,6 +20,7 @@
 	"description": "Astro Web Component for mission clock",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"main": "rux-clock.js",
+  "module": "rux-clock.js",
 	"name": "@astrouxds/rux-clock",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-global-status-bar/README.md
+++ b/src/components/rux-global-status-bar/README.md
@@ -18,15 +18,15 @@ npm i -save @astrouxds/rux-global-status-bar
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Global Status Bar Web Component
 

--- a/src/components/rux-global-status-bar/README.md
+++ b/src/components/rux-global-status-bar/README.md
@@ -26,7 +26,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Global Status Bar Web Component
 

--- a/src/components/rux-global-status-bar/package.json
+++ b/src/components/rux-global-status-bar/package.json
@@ -10,11 +10,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for global status bar",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-global-status-bar/package.json
+++ b/src/components/rux-global-status-bar/package.json
@@ -19,6 +19,7 @@
   "description": "Astro Web Component for global status bar",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-global-status-bar.js",
+  "module": "rux-global-status-bar.js",
   "name": "@astrouxds/rux-global-status-bar",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-icon/README.md
+++ b/src/components/rux-icon/README.md
@@ -30,7 +30,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Icon Web Component
 

--- a/src/components/rux-icon/README.md
+++ b/src/components/rux-icon/README.md
@@ -22,15 +22,15 @@ npm i --save @astrouxds/rux-icon
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Icon Web Component
 

--- a/src/components/rux-icon/package.json
+++ b/src/components/rux-icon/package.json
@@ -10,11 +10,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for Icons",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-icon/package.json
+++ b/src/components/rux-icon/package.json
@@ -19,6 +19,7 @@
   "description": "Astro Web Component for Icons",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-icon.js",
+  "module": "rux-icon.js",
   "name": "@astrouxds/rux-icon",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-log/README.md
+++ b/src/components/rux-log/README.md
@@ -27,7 +27,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Log Web Component
 

--- a/src/components/rux-log/README.md
+++ b/src/components/rux-log/README.md
@@ -19,15 +19,15 @@ npm i --save @astrouxds/rux-log
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Log Web Component
 

--- a/src/components/rux-log/package.json
+++ b/src/components/rux-log/package.json
@@ -11,11 +11,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for logs",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-log/package.json
+++ b/src/components/rux-log/package.json
@@ -20,6 +20,7 @@
   "description": "Astro Web Component for logs",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-log.js",
+  "module": "rux-log.js",
   "name": "@astrouxds/rux-log",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-modal/README.md
+++ b/src/components/rux-modal/README.md
@@ -20,15 +20,15 @@ npm i --save @astrouxds/rux-modal
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Dialog Box Web Component
 

--- a/src/components/rux-modal/README.md
+++ b/src/components/rux-modal/README.md
@@ -28,7 +28,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Dialog Box Web Component
 

--- a/src/components/rux-modal/README.md
+++ b/src/components/rux-modal/README.md
@@ -69,7 +69,7 @@ Pass properties as attributes of the Astro Dialog Box custom element:
 
 ### Event Listener
 
-When closed, the Dialog Box Web Component will emit a message using the `'modal-event'` event name and a detail message of `confirm` with a value of `true` (confirm) or `false` (deny) depending on whether the user clicks the confirm or deny button.
+When closed, the Dialog Box Web Component will emit a message using the `'modalClosed'` event name and a detail message of `confirm` with a value of `true` (confirm) or `false` (deny) depending on whether the user clicks the confirm or deny button.
 
 ## Revision History
 

--- a/src/components/rux-modal/package.json
+++ b/src/components/rux-modal/package.json
@@ -10,11 +10,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for modal dialogue",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-modal/package.json
+++ b/src/components/rux-modal/package.json
@@ -19,6 +19,7 @@
   "description": "Astro Web Component for modal dialogue",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-modal.js",
+  "module": "rux-modal.js",
   "name": "@astrouxds/rux-modal",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-monitoring-icon/README.md
+++ b/src/components/rux-monitoring-icon/README.md
@@ -26,7 +26,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Monitoring Icon Web Component
 
@@ -89,7 +89,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Monitoring Progress Icon Web Component
 

--- a/src/components/rux-monitoring-icon/README.md
+++ b/src/components/rux-monitoring-icon/README.md
@@ -18,15 +18,15 @@ npm i --save @astrouxds/rux--monitoring-icon
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Monitoring Icon Web Component
 
@@ -81,15 +81,15 @@ npm i --save @astrouxds/rux--monitoring-icon
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Monitoring Progress Icon Web Component
 

--- a/src/components/rux-monitoring-icon/package.json
+++ b/src/components/rux-monitoring-icon/package.json
@@ -12,11 +12,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for Monitoring Icons",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-monitoring-icon/package.json
+++ b/src/components/rux-monitoring-icon/package.json
@@ -21,6 +21,7 @@
   "description": "Astro Web Component for Monitoring Icons",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-monitoring-icon.js",
+  "module": "rux-monitoring-icon.js",
   "name": "@astrouxds/rux-monitoring-icon",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-notification/README.md
+++ b/src/components/rux-notification/README.md
@@ -32,7 +32,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Notiication Banner Web Component
 

--- a/src/components/rux-notification/README.md
+++ b/src/components/rux-notification/README.md
@@ -24,15 +24,15 @@ npm i --save @astrouxds/rux-notification
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Notiication Banner Web Component
 

--- a/src/components/rux-notification/package.json
+++ b/src/components/rux-notification/package.json
@@ -11,11 +11,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for notification banners",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-notification/package.json
+++ b/src/components/rux-notification/package.json
@@ -20,6 +20,7 @@
   "description": "Astro Web Component for notification banners",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-notification.js",
+  "module": "rux-notification.js",
   "name": "@astrouxds/rux-notification",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-pop-up-menu/README.md
+++ b/src/components/rux-pop-up-menu/README.md
@@ -24,7 +24,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Pop Up Menu Web Component
 

--- a/src/components/rux-pop-up-menu/README.md
+++ b/src/components/rux-pop-up-menu/README.md
@@ -16,15 +16,15 @@ npm i --save @astrouxds/rux-pop-up-menu
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Pop Up Menu Web Component
 

--- a/src/components/rux-pop-up-menu/package.json
+++ b/src/components/rux-pop-up-menu/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for pop-up menus",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-pop-up-menu/package.json
+++ b/src/components/rux-pop-up-menu/package.json
@@ -16,6 +16,7 @@
   "description": "Astro Web Component for pop-up menus",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-pop-up-menu.js",
+  "module": "rux-pop-up-menu.js",
   "name": "@astrouxds/rux-pop-up-menu",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-progress/README.md
+++ b/src/components/rux-progress/README.md
@@ -24,7 +24,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download Astro Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download Astro Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Astro Template Web Component
 

--- a/src/components/rux-progress/README.md
+++ b/src/components/rux-progress/README.md
@@ -16,15 +16,15 @@ npm i --save @astrouxds/rux-progress
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download Astro Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download Astro Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Astro Template Web Component
 
@@ -62,7 +62,7 @@ For projects where Web Components are not a viable option use the Astro CSS and 
 
 ### 1. Include the Astro UXDS CSS file
 
-Latest release is available in [Astro Styles repo](https://bitbucket.org/rocketcom/astro-styles/src/master/).
+Latest release is available in the [static css directory](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static/css).
 
 ```xml
 <link rel="stylesheet" href="/your-project/path/astro.css" />

--- a/src/components/rux-progress/package.json
+++ b/src/components/rux-progress/package.json
@@ -10,11 +10,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for both determinate and indeterminate progress indicators",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-progress/package.json
+++ b/src/components/rux-progress/package.json
@@ -19,6 +19,7 @@
   "description": "Astro Web Component for both determinate and indeterminate progress indicators",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-progress.js",
+  "module": "rux-progress.js",
   "name": "@astrouxds/rux-progress",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-push-button/README.md
+++ b/src/components/rux-push-button/README.md
@@ -26,7 +26,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Push Button Web Component
 

--- a/src/components/rux-push-button/README.md
+++ b/src/components/rux-push-button/README.md
@@ -18,15 +18,15 @@ npm i --save @astrouxds/rux-push-button
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Push Button Web Component
 
@@ -59,7 +59,7 @@ Provide a label for the Push Button inside the component node using the componen
 
 ### 1. Include the Astro UXDS CSS file
 
-Latest release is available in [Astro UXDS Styles repo](https://bitbucket.org/rocketcom/astro-styles/src/master/).
+Latest release is available in the [static css directory](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static/css).
 
 ```xml
 <link rel="stylesheet" href="/your-project/path/astro.css" />
@@ -92,7 +92,7 @@ Apply attributes such as `disabled` and/or `checked` on the `<input>` element.
 | `disabled` | Boolean | `false` | No       | Disables the button via HTML `disabled` attribute. Button takes on a distinct visual state. Cursor uses the `not-allowed` system replacement and all keyboard and mouse events are ignored. |
 | `checked`  | Boolean | `false` | No       | Checks the button via HTML `checked` attribute. Button takes on a distinct "enabled" or "selected" visual state.                                                                            |
 
-For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://bitbucket.org/rocketcom/astro-styles)
+For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://www.astrouxds.com/components/readme/#getting-started-with-html-%26-css)
 
 ## Revision History
 

--- a/src/components/rux-push-button/package.json
+++ b/src/components/rux-push-button/package.json
@@ -19,6 +19,7 @@
   "description": "Astro Web Component for push buttons",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-push-button.js",
+  "module": "rux-push-button.js",
   "name": "@astrouxds/rux-push-button",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-push-button/package.json
+++ b/src/components/rux-push-button/package.json
@@ -10,11 +10,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for push buttons",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-segmented-button/README.md
+++ b/src/components/rux-segmented-button/README.md
@@ -26,7 +26,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Segmented Button Web Component
 

--- a/src/components/rux-segmented-button/README.md
+++ b/src/components/rux-segmented-button/README.md
@@ -18,15 +18,15 @@ npm i --save @astrouxds/rux-segmented-button
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Segmented Button Web Component
 
@@ -81,7 +81,7 @@ render() {
 
 ### 1. Include the Astro UXDS CSS file
 
-Latest release is available in [Astro UXDS Styles repo](https://bitbucket.org/rocketcom/astro-styles/src/master/).
+Latest release is available in the [static css directory](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static/css).
 
 ```xml
 <link rel="stylesheet" href="/your-project/path/astro.css" />

--- a/src/components/rux-segmented-button/package.json
+++ b/src/components/rux-segmented-button/package.json
@@ -10,11 +10,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for segmented buttons",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-segmented-button/package.json
+++ b/src/components/rux-segmented-button/package.json
@@ -19,6 +19,7 @@
   "description": "Astro Web Component for segmented buttons",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-segmented-button.js",
+  "module": "rux-segmented-button.js",
   "name": "@astrouxds/rux-segmented-button",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-slider/README.md
+++ b/src/components/rux-slider/README.md
@@ -19,15 +19,15 @@ npm i -save @astrouxds/rux-slider
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Slider Web Component
 

--- a/src/components/rux-slider/README.md
+++ b/src/components/rux-slider/README.md
@@ -27,7 +27,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Slider Web Component
 

--- a/src/components/rux-slider/package.json
+++ b/src/components/rux-slider/package.json
@@ -10,11 +10,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for sliders",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-slider/package.json
+++ b/src/components/rux-slider/package.json
@@ -19,6 +19,7 @@
   "description": "Astro Web Component for sliders",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-slider.js",
+  "module": "rux-slider.js",
   "name": "@astrouxds/rux-slider",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-status/README.md
+++ b/src/components/rux-status/README.md
@@ -26,7 +26,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Status Web Component
 

--- a/src/components/rux-status/README.md
+++ b/src/components/rux-status/README.md
@@ -18,15 +18,15 @@ npm i --save @astrouxds/rux-status
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Status Web Component
 
@@ -56,7 +56,7 @@ Pass properties as attributes of the Astro Status custom element:
 
 ### 1. Include the Astro UXDS CSS file
 
-Latest release is available in [Astro UXDS Styles repo](https://bitbucket.org/rocketcom/astro-styles/src/master/).
+Latest release is available in the [static css directory](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static/css).
 
 ```xml
 <link rel="stylesheet" href="/your-project/path/astro.css" />

--- a/src/components/rux-status/package.json
+++ b/src/components/rux-status/package.json
@@ -19,6 +19,7 @@
   "description": "Astro Web Component for status indicator",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-status.js",
+  "module": "rux-status.js",
   "name": "@astrouxds/rux-status",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-status/package.json
+++ b/src/components/rux-status/package.json
@@ -10,11 +10,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for status indicator",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-tabs/README.md
+++ b/src/components/rux-tabs/README.md
@@ -18,15 +18,15 @@ npm i --save @astrouxds/rux-tabs
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Tabs Web Component
 

--- a/src/components/rux-tabs/README.md
+++ b/src/components/rux-tabs/README.md
@@ -26,7 +26,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Tabs Web Component
 

--- a/src/components/rux-tabs/package.json
+++ b/src/components/rux-tabs/package.json
@@ -10,11 +10,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for tabs",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-tabs/package.json
+++ b/src/components/rux-tabs/package.json
@@ -19,6 +19,7 @@
   "description": "Astro Web Component for tabs",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-tabs.js",
+  "module": "rux-tabs.js",
   "name": "@astrouxds/rux-tabs",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-timeline/package.json
+++ b/src/components/rux-timeline/package.json
@@ -11,11 +11,11 @@
 	"homepage": "https://www.astrouxds.com",
 	"bugs": {
 		"email": "uxsupport@rocketcom.com",
-		"url": "https://bitbucket.org/rocketcom/astro-components/issues"
+		"url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+		"url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
 	},
 	"description": "Astro Web Component for Timeline Navigation",
 	"license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-timeline/package.json
+++ b/src/components/rux-timeline/package.json
@@ -20,6 +20,7 @@
 	"description": "Astro Web Component for Timeline Navigation",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"main": "rux-timeline.js",
+  "module": "rux-timeline.js",
 	"name": "@astrouxds/rux-timeline",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-toggle/package.json
+++ b/src/components/rux-toggle/package.json
@@ -10,11 +10,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for toggles",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-toggle/package.json
+++ b/src/components/rux-toggle/package.json
@@ -19,6 +19,7 @@
   "description": "Astro Web Component for toggles",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-toggle.js",
+  "module": "rux-toggle.js",
   "name": "@astrouxds/rux-toggle",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-tree/README.md
+++ b/src/components/rux-tree/README.md
@@ -57,14 +57,16 @@ import { RuxTree } from '@astrouxds/rux-tree/rux-tree.js';
  {
   label: "Option 1",
   status: "critical",
+  expanded: "true",
   children: [{
-   label: "Option 1.1"
-   status: "normal"
+   label: "Option 1.1",
+   status: "normal",
+   selected: "true",
    children: [ …] }]
  },
  {
-  label: "Option 1.2"
-  status: "normal"
+  label: "Option 1.2",
+  status: "normal",
   children: [ …]
  },
  {
@@ -80,6 +82,8 @@ import { RuxTree } from '@astrouxds/rux-tree/rux-tree.js';
 | ---------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `label`    | String | yes      | The label for the tree item                                                                                                                 |
 | `id`       | String | no       | An optional property to help identify individual tree elements                                                                              |
+| `selected` | Boolean | no      | If set to `true`, this item shows a selected style. When a new item is selected by user click, all other selected items are unselected. |
+| `expanded` | Boolean | no      | If set to `true`, this item is expanded. Multiple items can be expanded at the same time. |
 | `status`   | String | no       | An optional property to assign status. See [Astro Status](http://www.astrouxds.com/library/tree) for valid status options                   |
 | `children` | Array  | no       | An array of child elements. Children use the same structure as parents and may include their own `children` array to create nested elements |
 

--- a/src/components/rux-tree/README.md
+++ b/src/components/rux-tree/README.md
@@ -28,7 +28,7 @@ Via CLI:
 git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download Astro Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
+Or, [download Astro Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/archive/master.zip)
 
 ### 2. Import the Astro Tree Web Component
 

--- a/src/components/rux-tree/README.md
+++ b/src/components/rux-tree/README.md
@@ -20,15 +20,15 @@ npm i --save @astrouxds/rux-tree
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro Component Library](https://bitbucket.org/rocketcom/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
 
 Via CLI:
 
 ```sh
-git clone https://bitbucket.org/rocketcom/astro-components.git
+git clone https://github.com/RocketCommunicationsInc/astro-components.git
 ```
 
-Or, [download Astro Components as a .zip](https://bitbucket.org/rocketcom/astro-components/get/master.zip)
+Or, [download Astro Components as a .zip](https://github.com/RocketCommunicationsInc/astro-components/get/master.zip)
 
 ### 2. Import the Astro Tree Web Component
 

--- a/src/components/rux-tree/package.json
+++ b/src/components/rux-tree/package.json
@@ -19,6 +19,7 @@
   "description": "Astro Web Component for Tree Navigation",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "rux-tree.js",
+  "module": "rux-tree.js",
   "name": "@astrouxds/rux-tree",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/components/rux-tree/package.json
+++ b/src/components/rux-tree/package.json
@@ -10,11 +10,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Astro Web Component for Tree Navigation",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/rux-utils/package.json
+++ b/src/components/rux-utils/package.json
@@ -6,11 +6,11 @@
   "homepage": "https://www.astrouxds.com",
   "bugs": {
     "email": "uxsupport@rocketcom.com",
-    "url": "https://bitbucket.org/rocketcom/astro-components/issues"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://www.bitbucket.org/rocketcom/astro-components/src/master"
+    "url": "https://github.com/RocketCommunicationsInc/astro-components/src/master"
   },
   "description": "Utilities for Astro Components",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/css/documentation/checkboxes-README.md
+++ b/src/css/documentation/checkboxes-README.md
@@ -12,7 +12,7 @@ A Checkbox describes a state or value that can be either “On or Off.” Checkb
 
 ### 1. Include the Astro UXDS CSS file
 
-Latest release is available in [Astro UXDS Styles repo](https://bitbucket.org/rocketcom/astro-styles/src/master/).
+Latest release is available in the [static css directory](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static/css).
 
 ```xml
 <link rel="stylesheet" href="/your-project/path/astro.css" />
@@ -38,4 +38,4 @@ Wrap an input field and its associated label in an element with the `rux-checkbo
 | `required` | Boolean | `false` | No | Follows native form element `required` behavior, preventing submission of the form until a valid value has been entered. |
 
 
-For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://bitbucket.org/rocketcom/astro-styles)
+For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://www.astrouxds.com/components/readme/#getting-started-with-html-%26-css)

--- a/src/css/documentation/input-fields-README.md
+++ b/src/css/documentation/input-fields-README.md
@@ -11,7 +11,7 @@ Input Fields allow users to enter text or numeric data.
 
 ### 1. Include the Astro UXDS CSS file
 
-Latest release is available in [Astro UXDS Styles repo](https://bitbucket.org/rocketcom/astro-styles/src/master/).
+Latest release is available in the [static css directory](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static/css).
 
 ```xml
 <link rel="stylesheet" href="/your-project/path/astro.css" />
@@ -44,7 +44,7 @@ Apply the class `rux-form-field--small` to style the input element and label sma
 | `disabled` | Boolean | `false` | No | Disables the button via HTML `disabled` attribute. Button takes on a distinct visual state. Cursor uses the `not-allowed` system replacement and all keyboard and mouse events are ignored. |
 | `required` | Boolean | `false` | No | Follows native form element `required` behavior, preventing submission of the form until a valid value has been entered. |
 
-For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://bitbucket.org/rocketcom/astro-styles)
+For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://www.astrouxds.com/components/readme/#getting-started-with-html-%26-css)
 
 ### HTML5 Coverage
 

--- a/src/css/documentation/radio-buttons-README.md
+++ b/src/css/documentation/radio-buttons-README.md
@@ -12,7 +12,7 @@ Radio Buttons allow users to mutually select an option from a predefined set of 
 
 ### 1. Include the Astro UXDS CSS file
 
-Latest release is available in [Astro UXDS Styles repo](https://bitbucket.org/rocketcom/astro-styles/src/master/).
+Latest release is available in the [static css directory](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static/css).
 
 ```xml
 <link rel="stylesheet" href="/your-project/path/astro.css" />
@@ -39,4 +39,4 @@ Wrap an input field and its associated label in an element with the `rux-radio-b
 | `required` | Boolean | `false` | No | Follows native form element `required` behavior, preventing submission of the form until a valid value has been entered. |
 
 
-For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://bitbucket.org/rocketcom/astro-styles)
+For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://www.astrouxds.com/components/readme/#getting-started-with-html-%26-css)

--- a/src/css/documentation/select-menu-README.md
+++ b/src/css/documentation/select-menu-README.md
@@ -11,7 +11,7 @@ Drop Down Menus allow users to select a value from a list of values.
 
 ### 1. Include the Astro UXDS CSS file
 
-Latest release is available in [Astro UXDS Styles repo](https://bitbucket.org/rocketcom/astro-styles/src/master/).
+Latest release is available in the [static css directory](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static/css).
 
 ```xml
 <link rel="stylesheet" href="/your-project/path/astro.css" />
@@ -56,4 +56,4 @@ Add native HTML form attributes like `disabled` or `required` , or wrap options 
 | `disabled` | Boolean | `false` | No | Disables the button via HTML `disabled` attribute. Button takes on a distinct visual state. Cursor uses the `not-allowed` system replacement and all keyboard and mouse events are ignored. |
 | `required` | Boolean | `false` | No | Follows native form element `required` behavior, preventing submission of the form until a valid value has been entered. |
 
-For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://bitbucket.org/rocketcom/astro-styles)
+For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://www.astrouxds.com/components/readme/#getting-started-with-html-%26-css)

--- a/src/css/documentation/table-README.md
+++ b/src/css/documentation/table-README.md
@@ -10,7 +10,7 @@ Tables display tabular data in two dimensions.
 
 ### 1. Include the Astro UXDS CSS file
 
-Latest release is available in [Astro UXDS Styles repo](https://bitbucket.org/rocketcom/astro-styles/src/master/).
+Latest release is available in the [static css directory](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static/css).
 
 ```xml
 <link rel="stylesheet" href="/your-project/path/astro.css" />
@@ -59,4 +59,4 @@ Add a data attribute to indicate selected rows, and define column header cells u
 | `data-selected` | Boolean | `false` | No | Changes the background color of the row. Can be applied to multiple rows at once. |
 
 
-For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://bitbucket.org/rocketcom/astro-styles)
+For more information about AstroUXDS usage outside of a Web Component environment, please see [Astro UXDS Stylesheets](https://www.astrouxds.com/components/readme/#getting-started-with-html-%26-css)

--- a/stories/astro.stories.js
+++ b/stories/astro.stories.js
@@ -92,9 +92,9 @@ export const StartHere = () => {
     </p>
     <p>
       If you would like to download and run the Astro UXDS Components Storybook yourself, you may clone <a 
-      href="https://bitbucket.org/rocketcom/astro-components.git" target="_blank">the repository</a>:
+      href="https://github.com/RocketCommunicationsInc/astro-components.git" target="_blank">the repository</a>:
     </p>
-    <code class="language-sh">git clone https://bitbucket.org/rocketcom/astro-components.git</code>
+    <code class="language-sh">git clone https://github.com/RocketCommunicationsInc/astro-components.git</code>
 
   </div>
 `;

--- a/stories/rux-tree.stories.js
+++ b/stories/rux-tree.stories.js
@@ -14,13 +14,13 @@ export const Tree = () => {
     {
       label: 'Tree Item 1',
       expanded: true,
-      selected: true,
       children: [
         {
           label: 'Tree Item 1.1',
+          expanded: true,
           children: [
             { label: 'Tree Item 1.1.1' },
-            { label: 'Tree Item 1.1.2' },
+            { label: 'Tree Item 1.1.2', selected: true },
             { label: 'Tree Item 1.1.3' },
           ],
         },


### PR DESCRIPTION
Fixes for these documentation bugs:

- Replace all instances of bitbucket links to GitHub in astro-components [ASTRO-507]
- Add selected and expanded properties Tree Readme [ASTRO-502]
- 'modal-event' should be 'modalClosed' in modal Readme [ASTRO-490]
- All components should have module added to package.json [ASTRO-456]
