### PR TITLE
remove quotes around boolean

### DIFF
--- a/src/components/rux-tree/README.md
+++ b/src/components/rux-tree/README.md
@@ -57,11 +57,11 @@ import { RuxTree } from '@astrouxds/rux-tree/rux-tree.js';
  {
   label: "Option 1",
   status: "critical",
-  expanded: "true",
+  expanded: true,
   children: [{
    label: "Option 1.1",
    status: "normal",
-   selected: "true",
+   selected: true,
    children: [ …] }]
  },
  {


### PR DESCRIPTION
I added this in https://github.com/RocketCommunicationsInc/astro-components/pull/8/commits/f3a630f67bda0c27e9fae800c92f0dd56c409971 and shouldn't have quoted the booleans. Derp.