### PR TITLE
Expose selected property and change handlers on segmented button

### DIFF
--- a/src/components/rux-segmented-button/README.md
+++ b/src/components/rux-segmented-button/README.md
@@ -45,14 +45,14 @@ import { RuxSegmentedButton } from '@astrouxds/rux-segmented-button/rux-segmente
 
 const myButtonSegments = [
   { label: "First Segment" },
-  { label: "Second Segment", selected: true },
+  { label: "Second Segment" },
   { label: "Third Segment" }
 ];
 
 // ...
 
 render() {
-	return `<rux-segmented-button data="${myButtonSegments}"></rux-segmented-button>`;
+	return `<rux-segmented-button data="${myButtonSegments}" selected="${myButtonSegments[1].label}"></rux-segmented-button>`;
 }
 ```
 
@@ -61,19 +61,39 @@ render() {
 | Property | Type  | Default | Required | Description                                             |
 | -------- | ----- | ------- | -------- | ------------------------------------------------------- |
 | `data`   | Array | `[]`    | Yes      | Items in this Array are the individual button segments. |
+| `selected` | String | —       | No    | When passed in on load, this selects the first button segment with a matching label. When the selected segment changes, this property updates with the currently selected value, which reflects back to the component attribute. If no button segment label matches this string, then no segment is selected. This value takes priority over setting `selected` boolean property on the items in the `data` array. |
+
 
 ### Sample Astro UXDS Segmented Button `data` Array
 
 ```js
-[{ label: 'First Segment' }, { label: 'Second Segment', selected: true }, { label: 'Third Segment' }];
+[{ label: 'First Segment' }, { label: 'Second Segment' }, { label: 'Third Segment' }];
 ```
 
 ### Properties for items within the `data` Array
 
-| Property   | Type    | Default | Required | Description                                                                                                                                                                                                             |
-| ---------- | ------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `label`    | String  | —       | Yes      | Defines the label for the button segment.                                                                                                                                                                               |
-| `selected` | Boolean | —       | No       | If true, selects this segment rather than the first segment in the `data` Array on mount. If more than one segment has a truthy `selected` value, the earliest one in the Array will register and the rest are ignored. |
+| Property   | Type    | Default | Required | Description |
+| ---------- | ------- | ------- | -------- | ------------------------------------------------------- |
+| `label`    | String  | —       | Yes      | Defines the label for the button segment. |
+| `selected` | Boolean | —       | No       | If true, selects this segment rather than the first segment in the `data` Array on mount. If more than one segment has a truthy `selected` value, the earliest one in the Array will register and the rest are ignored. Note that if the `selected` string property of the parent `rux-segmented-button` takes priority. When the selected segment changes within the component, this property updates with `true` or `false` if selected or not selected, on each segment.|
+
+### Events
+
+| Event Name | Description |
+| --- | ---|
+| `change` | Fires when a button segment is changed. Inspect the Event target to find the `data` and `selected` component properties. See [HTMLElement `change` event on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) for more information. |
+
+```js 
+  document.addEventListener('change', (e) => console.log('Target element:', e.target)); 
+  // > Target element: <rux-segmented-button>
+
+  document.addEventListener('change', (e) => console.log('Selected Segment:', e.target.selected));
+  // > Selected Segment: Second Segment
+
+  document.addEventListener('change', (e) => console.log('Array of Segments:', e.target.data));
+  // > Array of Segments: [{ label: "First Segment", selected: false }, { label: "Second Segment", selected: true }, { label: "Third Segment", selected: false }]
+
+```
 
 ---
 
@@ -119,6 +139,10 @@ Configure the component using native HTML attributes. For each group of radio bu
 | `required` | Boolean | `false` | No       | Follows native form element `required` behavior, preventing submission of the form until a valid value has been entered. |
 
 ## Revision History
+
+##### **4.1**
+- Exposed `selected` attribute on component to reflect currently selected segment to an attribute on the component
+- Added `change` event to notify document of segment selection change within component
 
 ##### **4.0**
 

--- a/src/components/rux-segmented-button/rux-segmented-button.js
+++ b/src/components/rux-segmented-button/rux-segmented-button.js
@@ -7,20 +7,56 @@ export class RuxSegmentedButton extends LitElement {
       data: {
         type: Array,
       },
+      selected: {
+        reflect: true,
+        type: String,
+      },
     };
   }
 
   constructor() {
     super();
     this.data = [{ label: 'No data passed' }];
+    this._selected = '';
+  }
+
+  get selected() {
+    return this._selected;
+  }
+
+  set selected(label) {
+    const prevSelection = this.selected;
+    this._selected = label;
+    this.data.forEach((segment) => {
+      segment.selected = segment.label === label;
+    });
+    this.requestUpdate('selected', prevSelection);
+  }
+
+  deselectSelected() {
+    const previousSelectedElement = this.querySelectorAll('input[checked]');
+    previousSelectedElement.forEach((element) => {
+      element.checked = false;
+    });
+  }
+
+  handleChange(event) {
+    this.selected = event.target.value;
+    this.dispatchEvent(
+        new Event('change', {
+          bubbles: true,
+          composed: true,
+        })
+    );
   }
 
   connectedCallback() {
     super.connectedCallback();
 
-    const selectedSegment = this.data.find((segment) => segment.selected) || this.data[0];
-    selectedSegment.selected = true;
+    const initialSelection = this.data.find((segment) => segment.selected) || this.data[0];
+    this.selected = initialSelection.label;
   }
+
 
   _slugify(label) {
     return `${RuxUtils.stringToSlug(label)}`;
@@ -112,10 +148,10 @@ export class RuxSegmentedButton extends LitElement {
         }
 
         /* 
-  OVERRIDE FOR IE 
-  Otherwise all segments get rounded corners. Need to override and re-enable
-  some style definitions.
-*/
+          OVERRIDE FOR IE 
+          Otherwise all segments get rounded corners. Need to override and re-enable
+          some style definitions.
+        */
 
         .rux-segmented-buttons.style-scope {
           border-radius: 3px 6px 6px 3px !important;
@@ -130,23 +166,23 @@ export class RuxSegmentedButton extends LitElement {
       </style>
 
       <ul class="rux-segmented-buttons">
-        ${this.data.map(
-      (item) => html`
+        ${this.data.map((item) => html`
             <li class="rux-segmented-button">
               <input
                 type="radio"
                 name="rux-group"
                 id="${this._slugify(item.label)}"
+                value="${item.label}"
                 ?checked="${item.selected}"
                 data-label="${item.label}"
+                @change=${this.handleChange}
               />
               <label for="${this._slugify(item.label)}">
                 ${item.label}
               </label>
             </li>
-          `
-  )}
-      </ul>
+          `)}
+    </ul>
     `;
   }
 }

--- a/stories/rux-segmented-button.stories.js
+++ b/stories/rux-segmented-button.stories.js
@@ -1,9 +1,13 @@
 import { html, render } from 'lit-html';
 import { RuxSegmentedButton } from '../src/components/rux-segmented-button/rux-segmented-button.js';
+import { radios, withKnobs } from '@storybook/addon-knobs';
+import {action} from '@storybook/addon-actions';
 import Readme from '../src/components/rux-segmented-button/README.md';
 
 export default {
   title: 'Components|Segmented Button',
+  decorators: [withKnobs],
+
 };
 
 export const SegmentedButton = () => {
@@ -12,10 +16,15 @@ export const SegmentedButton = () => {
     { label: 'Second Item', selected: true },
     { label: 'Third Item' },
   ];
+  const segments = radios('Initially Selected Segment',
+      ['First Item', 'Second Item', 'Third Item'],
+      'Second Item' );
+
+  document.addEventListener('change', (e) => action('change')(e.target));
 
   return html`
     <div style="padding: 10vh 5vw; display: flex; justify-content: center;">
-      <rux-segmented-button .data="${segmentButtonArray}"></rux-segmented-button>
+      <rux-segmented-button .data="${segmentButtonArray}" .selected="${segments}"></rux-segmented-button>
     </div>
   `;
 };

--- a/stories/rux-segmented-button.stories.js
+++ b/stories/rux-segmented-button.stories.js
@@ -13,11 +13,11 @@ export default {
 export const SegmentedButton = () => {
   const segmentButtonArray = [
     { label: 'First Item' },
-    { label: 'Second Item', selected: true },
-    { label: 'Third Item' },
+    { label: 'Second Item'},
+    { label: 'Third Item', selected: true },
   ];
   const segments = radios('Initially Selected Segment',
-      ['First Item', 'Second Item', 'Third Item'],
+      ['First Item', 'Second Item', 'Third Item', 'Missing Item'],
       'Second Item' );
 
   document.addEventListener('change', (e) => action('change')(e.target));


### PR DESCRIPTION
Satisfies https://rocketcom.atlassian.net/browse/ASTRO-552

Check the Actions tab in storybook to see the `change` event reach the parent, where the selected item is reflected to the `selected` attribute on `<rux-segmented-button>` as well as within the data array

https://deploy-preview-14--astro-components.netlify.app/?path=/story/components-segmented-button--segmented-button