### PR TITLE
Fix conflict with Angular rendering cycle

### DIFF
--- a/src/components/rux-pop-up-menu/README.md
+++ b/src/components/rux-pop-up-menu/README.md
@@ -60,7 +60,7 @@ Create a triggering element to initiate the pop up menu. **Note**: The trigger e
 | Property | Type   | Default | Required | Description                                                                |
 | -------- | ------ | ------- | -------- | -------------------------------------------------------------------------- |
 | `id`     | String | `-`     | Yes      | A unique identifier to associate the pop up menu with a triggering element |
-| `data`   | Array  | `-`     | Yes      | An array of objects that defines the pop up menu’s labels                  |
+| `data`   | Array  | `-`     | Yes      | An array of objects that defines the pop up menu’s labels. **Note:** when used in an Angular environment you may need to stringify the data property |
 
 ### Sample `data` Array
 

--- a/src/components/rux-pop-up-menu/rux-pop-up-menu.js
+++ b/src/components/rux-pop-up-menu/rux-pop-up-menu.js
@@ -26,7 +26,6 @@ export class RuxPopUpMenu extends LitElement {
     this.data = [];
     this.selected = {};
     this.expanded = false;
-    this._trigger = this.parentElement.querySelector(`[aria-controls="${this.id}"]`);
 
     this.left = 0;
     this.top = 0;
@@ -38,6 +37,7 @@ export class RuxPopUpMenu extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+    this._trigger = this.parentElement.querySelector(`[aria-controls="${this.id}"]`);
 
     this._trigger.addEventListener('mousedown', this._handleClick);
   }


### PR DESCRIPTION
When trying to use the pop-up menu within Angular, it breaks due to lifecycle conflicts with the Angular renderer. This just moves a call the the "parentElement" to a point in the Lit-Element lifecycle when that element is *certain* to be defined, rather than in the constructor, when Angular hasn't placed the element in the DOM yet.