### PR TITLE
Astro 1328

### DIFF
--- a/src/components/rux-tabs/rux-tab-panels.js
+++ b/src/components/rux-tabs/rux-tab-panels.js
@@ -16,7 +16,7 @@ export class RuxTabPanels extends LitElement {
       window.addEventListener('DOMContentLoaded', this._registerTabPanelsListener);
     } else {
       // Register Tab Panels if DOMContentLoaded event was already fired
-      this._registerTabPanelsListener;
+      this._registerTabPanelsListener();
     }
   }
 

--- a/src/components/rux-tabs/rux-tab-panels.js
+++ b/src/components/rux-tabs/rux-tab-panels.js
@@ -11,8 +11,13 @@ export class RuxTabPanels extends LitElement {
 
     this.setAttribute('style', 'position: relative; width: 100%;');
 
-    // Add event listener to wait for DOM to be completely loaded. This was needed for Angular
-    window.addEventListener('DOMContentLoaded', this._registerTabPanelsListener );
+    if (document.readyState === 'loading') {
+      // Add event listener to wait for DOM to be completely loaded. This was needed for Angular
+      window.addEventListener('DOMContentLoaded', this._registerTabPanelsListener);
+    } else {
+      // Register Tab Panels if DOMContentLoaded event was already fired
+      this._registerTabPanelsListener;
+    }
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
The issue here was that ```_registerTabPanels()``` wasn't firing when the component was being used in Storybook because the component is listening for the DOMContentLoaded event. I suspect this was already fired once somewhere in Storybook's lifecycle. To solve this, we can [check if loading is already complete](https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event#checking_whether_loading_is_already_complete) and execute ```_registerTabPanels()``` 

I don't know the historical context of why that event listener exists but it looks like it's related to an Angular issue. I tried to avoid making any changes to the component just to fix an issue with Storybook specifically, but I couldn't come up with any other solutions. 