### PR TITLE
Astro 1328

### DIFF
--- a/src/components/rux-tabs/rux-tab-panels.js
+++ b/src/components/rux-tabs/rux-tab-panels.js
@@ -16,7 +16,7 @@ export class RuxTabPanels extends LitElement {
       window.addEventListener('DOMContentLoaded', this._registerTabPanelsListener);
     } else {
       // Register Tab Panels if DOMContentLoaded event was already fired
-      this._registerTabPanelsListener;
+      this._registerTabPanelsListener();
     }
   }
 

--- a/src/components/rux-tabs/rux-tab-panels.js
+++ b/src/components/rux-tabs/rux-tab-panels.js
@@ -11,8 +11,13 @@ export class RuxTabPanels extends LitElement {
 
     this.setAttribute('style', 'position: relative; width: 100%;');
 
-    // Add event listener to wait for DOM to be completely loaded. This was needed for Angular
-    window.addEventListener('DOMContentLoaded', this._registerTabPanelsListener );
+    if (document.readyState === 'loading') {
+      // Add event listener to wait for DOM to be completely loaded. This was needed for Angular
+      window.addEventListener('DOMContentLoaded', this._registerTabPanelsListener);
+    } else {
+      // Register Tab Panels if DOMContentLoaded event was already fired
+      this._registerTabPanelsListener;
+    }
   }
 
   disconnectedCallback() {

--- a/src/components/rux-tabs/rux-tab-panels.js
+++ b/src/components/rux-tabs/rux-tab-panels.js
@@ -3,31 +3,29 @@ import { LitElement, html } from 'lit-element';
 export class RuxTabPanels extends LitElement {
   constructor() {
     super();
-    this._registerTabPanelsListener = this._registerTabPanels.bind(this);
+  }
+
+  firstUpdated() {
+    this._registerTabPanels();
+  }
+
+  get _slottedChildren() {
+    const slot = this.shadowRoot.querySelector('slot');
+    const childNodes = slot.assignedNodes({flatten: true});
+    return Array.prototype.filter.call(childNodes, (node) => node.nodeType == Node.ELEMENT_NODE);
   }
 
   connectedCallback() {
     super.connectedCallback();
-
     this.setAttribute('style', 'position: relative; width: 100%;');
-
-    if (document.readyState === 'loading') {
-      // Add event listener to wait for DOM to be completely loaded. This was needed for Angular
-      window.addEventListener('DOMContentLoaded', this._registerTabPanelsListener);
-    } else {
-      // Register Tab Panels if DOMContentLoaded event was already fired
-      this._registerTabPanelsListener();
-    }
   }
 
   disconnectedCallback() {
-    window.removeEventListener('DOMContentLoaded', this._registerTabPanelsListener);
     super.disconnectedCallback();
   }
 
   _registerTabPanels() {
-    let _panels = document.querySelectorAll('rux-tab-panel');
-
+    const _panels = this._slottedChildren;
     window.dispatchEvent(
       new CustomEvent('register-panels', {
         detail: { panels: _panels, for: this.getAttribute('aria-labelledby') },


### PR DESCRIPTION
Round two!

The problem with my last PR was that document.readyState isn't an accurate way to determine if the slot components have been rendered or not. The issue was still related to that DOMContentLoaded event not firing. The old code was listening to DOMContentLoaded so that it could grab the `rux-tab-panel` elements and pass them to the `rux-tabs` component via an event. The `rux-tabs` component is then responsible for setting the hidden class, marking as selected, etc. Without listening to that DOMContentLoaded event, `let _panels = document.querySelectorAll('rux-tab-panel');` was just returning an empty array.

So really all we need to do in `rux-tab-panels` is access the child panel nodes provided via <slot> and pass them up the chain. And that can be done easily using the HTMLSlotElement API. Removing the DOMContentLoaded listener entirely and following the [LitElement example](https://lit-element.polymer-project.org/guide/templates#accessing-slotted-children), everything works and we can eliminate the angular-specific fix that was in place. 

I tested this with storybook, a fresh angular app, and a fresh vue-cli app. The one possible issue I see is that the `_slottedChildren` method will return ALL children. So if someone were to do something like 

```<rux-tab-panels>
   <rux-tab-panel></rux-tab-panel>
   <div>whatup, this isnt actually a tab panel</div>
   <rux-tab-panel></rux-tab-panel>
```
that middle div would still be treated as a panel and the `rux-tab` could throw an error. But I don't think there's a real use case for that anyway and it could be solved by appending `node.nodeName === 'RUX-TAB-PANEL'` to the filter in `_slottedChildren`

This PR also fixes ASTRO-382, the issue with nesting multiple tabs (with one caveat). 