### PR TITLE
Astro 1066

### DIFF
--- a/src/components/rux-clock/rux-clock.js
+++ b/src/components/rux-clock/rux-clock.js
@@ -10,7 +10,7 @@ export class RuxClock extends LitElement {
   static get properties() {
     return {
       aos: {
-        type: String,
+        type: Number,
       },
       los: {
         type: String,

--- a/stories/rux-clock.stories.js
+++ b/stories/rux-clock.stories.js
@@ -56,11 +56,6 @@ Clock.story = {
 };
 
 export const ClockWithAosLos = () => {
-  function dateWrapper(name, defaultValue) {
-    const stringTimestamp = date(name, defaultValue);
-    return new Date(stringTimestamp);
-  }
-
   const timezones = {
     Guam: 'Pacific/Guam',
     Hawaii: 'Pacific/Honolulu',
@@ -75,8 +70,8 @@ export const ClockWithAosLos = () => {
   };
 
   const timezoneKnob = select('Timezone', timezones, 'UTC');
-  const aosKnob = dateWrapper('AOS', new Date(1557503698781));
-  const losKnob = dateWrapper('LOS', new Date('2019-05-10T16:21:12.000Z'));
+  const aosKnob = '1557503698781';
+  const losKnob = '2019-05-10T16:21:12.000Z';
   const hideTimezoneKnob = boolean('Hide Timezone', false);
   const hideDateKnob = boolean('Hide DOY', false);
   const smallKnob = boolean('Small Version', false);
@@ -84,8 +79,8 @@ export const ClockWithAosLos = () => {
     <div style="padding: 10%; display: flex; justify-content: center;">
       <rux-clock
         .timezone="${timezoneKnob}"
-        aos="${aosKnob.toString()}"
-        los="${losKnob.toString()}"
+        aos="${aosKnob}"
+        los="${losKnob}"
         ?hideTimezone="${hideTimezoneKnob}"
         ?hideDate="${hideDateKnob}"
         ?small="${smallKnob}"

--- a/stories/rux-clock.stories.js
+++ b/stories/rux-clock.stories.js
@@ -70,8 +70,9 @@ export const ClockWithAosLos = () => {
   };
 
   const timezoneKnob = select('Timezone', timezones, 'UTC');
-  const aosKnob = '1557503698781';
-  const losKnob = '2019-05-10T16:21:12.000Z';
+  const aosKnob = date('AOS', new Date());
+  const losKnob = date('LOS', new Date());
+  const losAsISO = new Date(losKnob).toISOString();
   const hideTimezoneKnob = boolean('Hide Timezone', false);
   const hideDateKnob = boolean('Hide DOY', false);
   const smallKnob = boolean('Small Version', false);
@@ -80,7 +81,7 @@ export const ClockWithAosLos = () => {
       <rux-clock
         .timezone="${timezoneKnob}"
         aos="${aosKnob}"
-        los="${losKnob}"
+        los="${losAsISO}"
         ?hideTimezone="${hideTimezoneKnob}"
         ?hideDate="${hideDateKnob}"
         ?small="${smallKnob}"


### PR DESCRIPTION
The issue here was mostly a formatting issue. The `utcToZonedTime` method from date-fns-tz won't accept a string if its a unix timestamp. The RuxClock component had the aos prop set to string so it was always converting it even if you pass in a number. 

I also added two knobs for AOS and LOC, mostly for my own sanity to test, but also because they were referenced as aosKnob and losKnob but weren't actually knobs. I can revert that if they were intentionally left out. 