### PR TITLE
Astro 445 

### DIFF
--- a/src/components/rux-notification/rux-notification.js
+++ b/src/components/rux-notification/rux-notification.js
@@ -74,7 +74,7 @@ export class RuxNotification extends LitElement {
           align-items: center;
           align-content: center;
 
-          top: -4.25rem;
+          top: -4.375rem;
           left: 0;
 
           height: 4.375rem;

--- a/src/components/rux-notification/rux-notification.js
+++ b/src/components/rux-notification/rux-notification.js
@@ -34,19 +34,20 @@ export class RuxNotification extends LitElement {
     this.target = 'local';
     this.closeAfter = null;
     this.open = false;
+    this.timerRef = null;
   }
 
   updated() {
     if (this._closeAfter && this.open) {
-      this.timerId = setTimeout(() => {
+      this.timerRef = setTimeout(() => {
         this.open = false;
       }, this._closeAfter);
     }
   }
 
   _onClick() {
-    if (this.timerId) {
-      clearTimeout(this.timerId);
+    if (this.timerRef) {
+      clearTimeout(this.timerRef);
     }
     this.open = false;
   }

--- a/src/components/rux-notification/rux-notification.js
+++ b/src/components/rux-notification/rux-notification.js
@@ -38,14 +38,16 @@ export class RuxNotification extends LitElement {
 
   updated() {
     if (this._closeAfter && this.open) {
-      this._closeAfter = setTimeout(() => {
+      this.timerId = setTimeout(() => {
         this.open = false;
       }, this._closeAfter);
     }
   }
 
   _onClick() {
-    clearTimeout(this._closeAfter);
+    if (this.timerId) {
+      clearTimeout(this.timerId);
+    }
     this.open = false;
   }
 

--- a/src/components/rux-notification/rux-notification.js
+++ b/src/components/rux-notification/rux-notification.js
@@ -34,20 +34,20 @@ export class RuxNotification extends LitElement {
     this.target = 'local';
     this.closeAfter = null;
     this.open = false;
-    this.timerRef = null;
+    this.timeoutRef = null;
   }
 
   updated() {
     if (this._closeAfter && this.open) {
-      this.timerRef = setTimeout(() => {
+      this.timeoutRef = setTimeout(() => {
         this.open = false;
       }, this._closeAfter);
     }
   }
 
   _onClick() {
-    if (this.timerRef) {
-      clearTimeout(this.timerRef);
+    if (this.timeoutRef) {
+      clearTimeout(this.timeoutRef);
     }
     this.open = false;
   }

--- a/src/components/rux-notification/rux-notification.js
+++ b/src/components/rux-notification/rux-notification.js
@@ -51,14 +51,14 @@ export class RuxNotification extends LitElement {
     this.open = false;
   }
 
-  // convert given time to miliseconds, enforce default 2s minimum delay
+  // convert given time to milliseconds, enforce default 2s minimum delay
   get _closeAfter() {
     if (this.closeAfter && this.closeAfter <= 10) {
       // if the number is 10 or less, it must be ms
     }
 
     if ((this.closeAfter && this.closeAfter > 10000) || (this.closeAfter && this.closeAfter < 2000)) {
-      // if this numner is larger than 10s or smaller than 2s, enforce minimum 2s delay
+      // if this number is larger than 10s or smaller than 2s, enforce minimum 2s delay
       this.closeAfter = 2000;
     }
 


### PR DESCRIPTION
Fixes an issue with the notification component not closing entirely and throwing an error when using the closeAfter feature. The error was related to trying to assign a value to `_closeAfter`, but there was no setter. 

I'm not sure if clearTimeout is even necessary here though. I'm assuming thats there to prevent any potential memory leaks? 