### PR TITLE
fix: change font weight on aos/los clock

### DIFF
--- a/src/components/rux-clock/rux-clock.js
+++ b/src/components/rux-clock/rux-clock.js
@@ -161,7 +161,7 @@ export class RuxClock extends LitElement {
         }
 
         .rux-clock__segment--secondary .rux-clock__segment__value {
-          font-weight: 100;
+          font-weight: 400;
         }
 
         .rux-clock__aos {


### PR DESCRIPTION
fixing very minor inconsistency in rux-clock where the aos/los labels font weight is defined as 100 but the design calls for 400. because we don't include Roboto Mono 100, its being rendered as 400 anyway so this effectively changes absolutely nothing visually. 