### PR TITLE
fix: missing close icon on notification banner

### DIFF
--- a/src/components/rux-notification/rux-notification.js
+++ b/src/components/rux-notification/rux-notification.js
@@ -127,7 +127,7 @@ export class RuxNotification extends LitElement {
         role="button"
         label="Close notification"
         @click="${this._onClick}"
-        icon="close-large"
+        icon="close"
         size="small"
       ></rux-icon>
     `;


### PR DESCRIPTION
Bug: [ASTRO-1452](https://rocketcom.atlassian.net/browse/ASTRO-1452)

Fixes [issue #187](https://github.com/RocketCommunicationsInc/astro-uxds/issues/187) - a major regression in the notification component where the close icon is no longer rendering. 

Issue seems to be caused by the rux-icon overhaul where the 'close-large' was removed. The notification component was referencing 'close-large' and therefore was not rendering. I replaced it with 'close' as seemed to be the closest alternative. 

Need feedback from UX/design to approve.