### PR TITLE
hotfix/fix readme link

### DIFF
--- a/src/components/__rux-template/README.md
+++ b/src/components/__rux-template/README.md
@@ -18,7 +18,7 @@ npm i --save @astrouxds/rux-template
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -33,7 +33,7 @@ Or, [download Astro UXDS Components as a .zip](https://github.com/RocketCommunic
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro UXDS Components directory in your project.
 
 ```javascript
-import { RuxTemplate } from '@astrouxds/rux-template/rux-template.js';
+import { RuxTemplate } from "@astrouxds/rux-template/rux-template.js";
 ```
 
 ### 3. Render the Astro Template Web Component

--- a/src/components/rux-accordion/README.md
+++ b/src/components/rux-accordion/README.md
@@ -18,7 +18,7 @@ npm i --save @astrouxds/rux-accordion
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -33,7 +33,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxAccordion } from '@astrouxds/rux-accordion/rux-accordion.js';
+import { RuxAccordion } from "@astrouxds/rux-accordion/rux-accordion.js";
 ```
 
 ### 3. Render the Astro Accordion Web Component

--- a/src/components/rux-button/README.md
+++ b/src/components/rux-button/README.md
@@ -18,7 +18,7 @@ npm i --save @astrouxds/rux-button
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -33,7 +33,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxButton } from '@astrouxds/rux-button/rux-button.js';
+import { RuxButton } from "@astrouxds/rux-button/rux-button.js";
 ```
 
 ### 3. Render the Astro Button Web Component
@@ -54,6 +54,7 @@ The component auto-imports the default Astro Icon Web Component for icons, if yo
   Button with icon using astro UXDS icon web component
 </rux-button>
 ```
+
 Also, you can use [Slots](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_templates_and_slots#Adding_flexibility_with_slots) to define icons within buttons. This method is best if you need to override the default icon library SVG file:
 
 ```xml
@@ -62,19 +63,18 @@ Also, you can use [Slots](https://developer.mozilla.org/en-US/docs/Web/Web_Compo
     Slotted icon button
   </rux-button>
 ```
+
 In this situation, you do not need to specify a size for the icon component -- the button's size attribute will define the appropriate size of the icon.
-
-
 
 ### Properties
 
-| Property   | Type    | Default | Required | Description                                                                                                                                                                                                                                                                |
-| ---------- | ------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `disabled` | Boolean | `false` | No       | Disables the button via HTML `disabled` attribute. Icon takes on a distinct visual state. Cursor uses the `not-allowed` system replacement and all keyboard and mouse events are ignored.                                                                                  |
-| `outline`  | Boolean | `false` | No       | Displays an outlined visual treatment suitable for secondary actions, such as a non-preferred alternative to an action identified by a standard button. For example, use an outline button for the less preferred option in Ok/Cancel button pairings.                     |
-| `iconOnly` | Boolean | `false` | No       | Visually hides all text on the button, suitable for use cases where space is at a premium and the button intent is unambiguous, like a Play/Pause button. Requires the `icon` attribute to be set as well.                                                                 |
+| Property   | Type    | Default | Required | Description                                                                                                                                                                                                                                                                                                                    |
+| ---------- | ------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `disabled` | Boolean | `false` | No       | Disables the button via HTML `disabled` attribute. Icon takes on a distinct visual state. Cursor uses the `not-allowed` system replacement and all keyboard and mouse events are ignored.                                                                                                                                      |
+| `outline`  | Boolean | `false` | No       | Displays an outlined visual treatment suitable for secondary actions, such as a non-preferred alternative to an action identified by a standard button. For example, use an outline button for the less preferred option in Ok/Cancel button pairings.                                                                         |
+| `iconOnly` | Boolean | `false` | No       | Visually hides all text on the button, suitable for use cases where space is at a premium and the button intent is unambiguous, like a Play/Pause button. Requires the `icon` attribute to be set as well.                                                                                                                     |
 | `icon`     | String  | `''`    | No       | Displays an Astro icon matching this string to the left of the button text. For a [full list of available icons, see the Icons section in Astro UXDS Guidelines](https://astrouxds.com/ui-components/icons-and-symbols). Required when the `iconOnly` attribute is `true`. Note that you can also use the Slot to add an icon. |
-| `size`     | String  | `''`    | No       | Displays the button as a `'small'` or `'large'` variant.                                                                                                                                                                                                                   |
+| `size`     | String  | `''`    | No       | Displays the button as a `'small'` or `'large'` variant.                                                                                                                                                                                                                                                                       |
 
 ---
 
@@ -139,6 +139,7 @@ For more information about AstroUXDS usage outside of a Web Component environmen
 ## Revision History
 
 ##### **4.1**
+
 - Add styles for and example of using slots for Icon child component
 
 ##### **4.0**

--- a/src/components/rux-classification-marking/README.md
+++ b/src/components/rux-classification-marking/README.md
@@ -4,11 +4,9 @@ Classification and control markings are required for digital products created fo
 
 For the most up-to-date policies, see the [ISOO Training Aids](https://www.archives.gov/isoo/training/training-aids) for classification marking policies and the [CUI Registry](https://www.archives.gov/cui) for control marking policies. In addition to these requirements, each government agency may have their own rules to use for classification and control markings.
 
-
 ## Guidelines
 
 - [Astro UXDS: Classification Markings](https://www.astrouxds.com/components/readme/)
-
 
 ## Web Components Usage
 
@@ -22,7 +20,7 @@ npm i --save @astrouxds/rux-classification-marking
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -37,7 +35,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxClassification } from '@astrouxds/rux-classification-marking/rux-classification-marking.js';
+import { RuxClassification } from "@astrouxds/rux-classification-marking/rux-classification-marking.js";
 ```
 
 ### 3. Render the Classification Markings Component
@@ -45,32 +43,44 @@ import { RuxClassification } from '@astrouxds/rux-classification-marking/rux-cla
 Pass properties as attributes of the Astro Classification custom element:
 
 ```javascript
-<rux-classification-marking classification="controlled" label=""></rux-classification-marking>
+<rux-classification-marking
+  classification="controlled"
+  label=""
+></rux-classification-marking>
 ```
 
-| Property       	| Type   	| Default  	| Required 	| Description 	|
-|----------------	|--------	|----------	|----------	|-------------	|
-| Classification 	| String 	| `'unclassified'`         	| Yes      	| This property            	|
-| Tag          	| Boolean 	| `false` 	| No      	| This property defines the marking as a`tag` rather than the default banner            	|
-| Label         	| String 	| `null` 	| No      	| This property allows additional text labels to be added to the a marking           	|
-
+| Property       | Type    | Default          | Required | Description                                                                |
+| -------------- | ------- | ---------------- | -------- | -------------------------------------------------------------------------- |
+| Classification | String  | `'unclassified'` | Yes      | This property                                                              |
+| Tag            | Boolean | `false`          | No       | This property defines the marking as a`tag` rather than the default banner |
+| Label          | String  | `null`           | No       | This property allows additional text labels to be added to the a marking   |
 
 #### Marking Type Declaration
- By default classification markings rendered in banner format. Applying the ```tag``` property attribute sets the marking type. The `tag` attribute property defines the classification marking as a tag.
+
+By default classification markings rendered in banner format. Applying the `tag` property attribute sets the marking type. The `tag` attribute property defines the classification marking as a tag.
 
 ##### Banner Marking Type
+
 ```javascript
-	<rux-classification-marking classification="controlled"></rux-classification-marking>
+<rux-classification-marking classification="controlled"></rux-classification-marking>
 ```
 
 ##### Tag Marking Type
+
 ```javascript
-	<rux-classification-marking classification="controlled" tag></rux-classification-marking>
+<rux-classification-marking
+  classification="controlled"
+  tag
+></rux-classification-marking>
 ```
 
 #### Custom Marking Labels
+
 Applying the `label` property attribute to the classification custom element adds `label` text value to the marking in addition to its classification text.
 
 ```javascript
-	<rux-classification-marking classification="controlled" label="//custom/label"></rux-classification-marking>
+<rux-classification-marking
+  classification="controlled"
+  label="//custom/label"
+></rux-classification-marking>
 ```

--- a/src/components/rux-clock/README.md
+++ b/src/components/rux-clock/README.md
@@ -18,7 +18,7 @@ npm i --save @astrouxds/rux-clock
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -33,7 +33,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxClock } from '@astrouxds/rux-clock/rux-clock.js';
+import { RuxClock } from "@astrouxds/rux-clock/rux-clock.js";
 ```
 
 ### 3. Render the Astro Clock Web Component
@@ -52,18 +52,19 @@ Define AOS and LOS with valid [Unix Time Stamp](http://pubs.opengroup.org/online
 
 ### Properties
 
-| Property       | Type    | Default | Required | Description                                                                                                                                                                                                                                                                                             |
-| -------------- | ------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `aos`          | String  | —       | No       | When supplied with a valid [date string or value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#syntax) displays a timestamp labeled "AOS" next to the standard clock.                                                                                          |
-| `los`          | String  | —       | No       | When supplied with a valid [date string or value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#syntax), displays a timestamp labeled "LOS" next to the standard clock.                                                                                         |
-| `timezone`     | String  | `'UTC'` | No       | Accepts the [IANA timezone string format](https://www.iana.org/time-zones) such as `'America/Los_Angeles'` or any single-character designation for a [military timezones](https://en.wikipedia.org/wiki/List_of_military_time_zones) (`'A'` through `'Z'`, excluding `'J'`), both case-insensitive. If no value for timezone is provided, the clock will use `'UTC'`. See [`toLocaleString()` on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString#Parameters) for more details.  |
-| `hideTimezone` | Boolean | `false` | No       | Hides the timezone in the main 24-hour clock. Timezone does not display on AOS/LOS.                                                                                                                                                                                                                     |
-| `hideDate`     | Boolean | `false` | No       | Hides the day of the year.                                                                                                                                                                                                                                                                              |
-| `small`        | Boolean | `false` | No       | Applies a smaller clock style. Previously `compact`                                                                                                                                                                                                                                                     |
+| Property       | Type    | Default | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| -------------- | ------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aos`          | String  | —       | No       | When supplied with a valid [date string or value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#syntax) displays a timestamp labeled "AOS" next to the standard clock.                                                                                                                                                                                                                                                                                                                               |
+| `los`          | String  | —       | No       | When supplied with a valid [date string or value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#syntax), displays a timestamp labeled "LOS" next to the standard clock.                                                                                                                                                                                                                                                                                                                              |
+| `timezone`     | String  | `'UTC'` | No       | Accepts the [IANA timezone string format](https://www.iana.org/time-zones) such as `'America/Los_Angeles'` or any single-character designation for a [military timezones](https://en.wikipedia.org/wiki/List_of_military_time_zones) (`'A'` through `'Z'`, excluding `'J'`), both case-insensitive. If no value for timezone is provided, the clock will use `'UTC'`. See [`toLocaleString()` on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString#Parameters) for more details. |
+| `hideTimezone` | Boolean | `false` | No       | Hides the timezone in the main 24-hour clock. Timezone does not display on AOS/LOS.                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `hideDate`     | Boolean | `false` | No       | Hides the day of the year.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `small`        | Boolean | `false` | No       | Applies a smaller clock style. Previously `compact`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 
 ## Revision History
 
 ##### **4.1**
+
 - Added moment.js for date/time calculations, fixing Day of Year count error at EOD
 - Added the 24 military timezone designations
 

--- a/src/components/rux-global-status-bar/README.md
+++ b/src/components/rux-global-status-bar/README.md
@@ -18,7 +18,7 @@ npm i -save @astrouxds/rux-global-status-bar
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -33,7 +33,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxGlobalStatusBar } from '@astrouxds/rux-global-status-bar/rux-global-status-bar.js';
+import { RuxGlobalStatusBar } from "@astrouxds/rux-global-status-bar/rux-global-status-bar.js";
 ```
 
 ### 3. Render the Astro Global Status Bar Web Component

--- a/src/components/rux-icon/README.md
+++ b/src/components/rux-icon/README.md
@@ -22,7 +22,7 @@ npm i --save @astrouxds/rux-icon
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -37,7 +37,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxIcon } from '@astrouxds/rux-icon/rux-icon.js';
+import { RuxIcon } from "@astrouxds/rux-icon/rux-icon.js";
 ```
 
 ### 3. Render the Astro Icon Web Component
@@ -88,6 +88,7 @@ In the SVG icon library file:
 <a name="astro-4-migration">
 
 ## Important Astro 4 Migration Note:
+
 Prior to Astro 4.0, the Astro UXDS Icon Component imported icons from a single SVG file where icons were identified by `id` under specific groups. In that method, icons were accessed via a namespaced value for the `icon` property, such as `"group-id:icon-id"`.
 
 ### Prior to Astro 4.0:

--- a/src/components/rux-log/README.md
+++ b/src/components/rux-log/README.md
@@ -19,7 +19,7 @@ npm i --save @astrouxds/rux-log
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -34,7 +34,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxLog } from '@astrouxds/rux-log/rux-log.js';
+import { RuxLog } from "@astrouxds/rux-log/rux-log.js";
 ```
 
 ### 3. Render the Astro Log Web Component
@@ -78,28 +78,28 @@ render() {
 [
   {
     timestamp: new Date(1557503698781), // date from Unix Time Stamp number
-    status: 'off',
-    message: 'Antenna DGS 1 went offline.',
+    status: "off",
+    message: "Antenna DGS 1 went offline.",
   },
   {
-    timestamp: new Date('2019-05-10T16:21:12.000Z'), // date from ISO 8601 string format
-    status: 'serious',
-    message: 'USA-177 experienced solar panel misalignment.',
-  },
-  {
-    timestamp: new Date(1557503698781),
-    status: 'caution',
-    message: 'USA-168 suffered power degradation.',
+    timestamp: new Date("2019-05-10T16:21:12.000Z"), // date from ISO 8601 string format
+    status: "serious",
+    message: "USA-177 experienced solar panel misalignment.",
   },
   {
     timestamp: new Date(1557503698781),
-    status: 'standby',
-    message: 'Antenna DGS 2 has weak signal.',
+    status: "caution",
+    message: "USA-168 suffered power degradation.",
   },
   {
     timestamp: new Date(1557503698781),
-    status: 'off',
-    message: 'Black FEP 121 is offline.',
+    status: "standby",
+    message: "Antenna DGS 2 has weak signal.",
+  },
+  {
+    timestamp: new Date(1557503698781),
+    status: "off",
+    message: "Black FEP 121 is offline.",
   },
 ];
 ```

--- a/src/components/rux-modal/README.md
+++ b/src/components/rux-modal/README.md
@@ -20,7 +20,7 @@ npm i --save @astrouxds/rux-modal
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -35,7 +35,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxModal } from '@astrouxds/rux-modal/rux-modal.js';
+import { RuxModal } from "@astrouxds/rux-modal/rux-modal.js";
 ```
 
 ### 3. Render the Astro Dialog Box Web Component
@@ -60,22 +60,26 @@ Pass properties as attributes of the Astro Dialog Box custom element:
 
 ### Properties
 
-| Property      | Type   | Default     | Required | Description                                                                                                                                                                                                                                                                                                                                                                             |
-| ------------- | ------ | ----------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `message`     | String | `''`        | Yes      | Displays a text for the message area of the dialog box.                                                                                                                                                                                                                                                                                                                                 |
-| `title`       | String | `''`        | No       | Displays a title for the top of the dialog box.                                                                                                                                                                                                                                                                                                                                         |
-| `confirmText` | String | `''`        | No       | Displays a confirmation button with the given text. If both `confirmText` and `denyText` parameters are set, the confirm button will have a solid style and the deny button will have a secondary outline style. If neither `confirmText` or `denyText` parameters are set, a deny button labeled "Cancel" will be provided to the user to dismiss the dialog and emit the close event. |
-| `denyText`    | String | `''`        | No       | Displays a deny button with the given text. If both `confirmText` and `denyText` parameters are set, the confirm button will have a solid style and the deny button will have a secondary outline style. If neither `confirmText` or `denyText` parameters are set, a deny button labeled "Cancel" will be provided to the user to dismiss the dialog and emit the close event.         |
+| Property      | Type   | Default | Required | Description                                                                                                                                                                                                                                                                                                                                                                             |
+| ------------- | ------ | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `message`     | String | `''`    | Yes      | Displays a text for the message area of the dialog box.                                                                                                                                                                                                                                                                                                                                 |
+| `title`       | String | `''`    | No       | Displays a title for the top of the dialog box.                                                                                                                                                                                                                                                                                                                                         |
+| `confirmText` | String | `''`    | No       | Displays a confirmation button with the given text. If both `confirmText` and `denyText` parameters are set, the confirm button will have a solid style and the deny button will have a secondary outline style. If neither `confirmText` or `denyText` parameters are set, a deny button labeled "Cancel" will be provided to the user to dismiss the dialog and emit the close event. |
+| `denyText`    | String | `''`    | No       | Displays a deny button with the given text. If both `confirmText` and `denyText` parameters are set, the confirm button will have a solid style and the deny button will have a secondary outline style. If neither `confirmText` or `denyText` parameters are set, a deny button labeled "Cancel" will be provided to the user to dismiss the dialog and emit the close event.         |
 
 ### Event Listener
 
 When closed, the Dialog Box Web Component will emit a message using the `'modalClosed'` event name and a detail message of `confirm` with a value of `true` (confirm) or `false` (deny) depending on whether the user clicks the confirm or deny button.
 
 ## Revision History
+
 ##### **5.0**
+
 - Added `--modalTitleColor` color variable for Modal Title Color
 - Removed CSS Fallback properties
+
 ##### **4.1**
+
 - Removed mention of Icon component
 
 ##### **4.0**

--- a/src/components/rux-monitoring-icon/MonitoringProgressReadme.md
+++ b/src/components/rux-monitoring-icon/MonitoringProgressReadme.md
@@ -18,7 +18,7 @@ npm i --save @astrouxds/rux--monitoring-icon
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 

--- a/src/components/rux-monitoring-icon/README.md
+++ b/src/components/rux-monitoring-icon/README.md
@@ -18,7 +18,7 @@ npm i --save @astrouxds/rux--monitoring-icon
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -33,7 +33,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxMonitoringIcon } from '@astrouxds/rux-monitoring-icon/rux-monitoring-icon.js';
+import { RuxMonitoringIcon } from "@astrouxds/rux-monitoring-icon/rux-monitoring-icon.js";
 ```
 
 ### 3. Render the Astro Monitoring Icon Web Component
@@ -52,19 +52,19 @@ Pass properties as attributes of the Astro Monitoring Icon custom element:
 
 ### Properties
 
-| Property        | Type   | Default    | Required | Description                                                                                                                                                                                                                                                                                       |
-| --------------- | ------ | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `icon`          | String | `''`       | Yes      | Displays an Astro icon matching this string. For a [full list of available icons, see the Icons section in Astro UXDS Guidelines](https://astrouxds.com/ui-components/icons-and-symbols)                                                                                                          |
-| `library` | String | `'/icons/astro.svg'`  | No       | Defines the root-relative path for a specific icon library SVG for this icon. An icon library SVG document has individual icon elements identified by an `id` property on the node (usually on a `<g>` or `<path>`). If a value for `library` is not provided, the icon component assumes the Astro library SVG exists at the default path, and will look for the icon by `id` there. |
-| `label`         | String | `'icon'`   | Yes      | Displays a label below the icon                                                                                                                                                                                                                                                                   |
-| `status`        | String | `'normal'` | Yes      | Styles the icon according to the Astro Status colors. Valid options are the Astro statuses `critical`, `serious`, `caution`, `normal`, `standby` and `off`                                                                                                                                        |
-| `sublabel`      | String | `''`       | No       | Displays a smaller label underneath the icon label                                                                                                                                                                                                                                                |
-| `notifications` | Number | `0`        | No       | If provided and greater than `0`, displays an outlined number badge at the bottom right of the icon. Numbers above `9999` are abbreviated to `'10K'` or `'100K'` for numbers in the thousands, `'1.5M'` for millions, and `'1.5B'` for billions. The badge uses `'∞'` for one trillion or higher. |
-
+| Property        | Type   | Default              | Required | Description                                                                                                                                                                                                                                                                                                                                                                           |
+| --------------- | ------ | -------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `icon`          | String | `''`                 | Yes      | Displays an Astro icon matching this string. For a [full list of available icons, see the Icons section in Astro UXDS Guidelines](https://astrouxds.com/ui-components/icons-and-symbols)                                                                                                                                                                                              |
+| `library`       | String | `'/icons/astro.svg'` | No       | Defines the root-relative path for a specific icon library SVG for this icon. An icon library SVG document has individual icon elements identified by an `id` property on the node (usually on a `<g>` or `<path>`). If a value for `library` is not provided, the icon component assumes the Astro library SVG exists at the default path, and will look for the icon by `id` there. |
+| `label`         | String | `'icon'`             | Yes      | Displays a label below the icon                                                                                                                                                                                                                                                                                                                                                       |
+| `status`        | String | `'normal'`           | Yes      | Styles the icon according to the Astro Status colors. Valid options are the Astro statuses `critical`, `serious`, `caution`, `normal`, `standby` and `off`                                                                                                                                                                                                                            |
+| `sublabel`      | String | `''`                 | No       | Displays a smaller label underneath the icon label                                                                                                                                                                                                                                                                                                                                    |
+| `notifications` | Number | `0`                  | No       | If provided and greater than `0`, displays an outlined number badge at the bottom right of the icon. Numbers above `9999` are abbreviated to `'10K'` or `'100K'` for numbers in the thousands, `'1.5M'` for millions, and `'1.5B'` for billions. The badge uses `'∞'` for one trillion or higher.                                                                                     |
 
 ## Revision History
 
 ##### **4.1**
+
 - Added `library` property to the Monitoring Icon component, enabling the use of custom SVG icon libraries.
 
 ##### **4.0**
@@ -76,6 +76,7 @@ Pass properties as attributes of the Astro Monitoring Icon custom element:
 <a name="astro-4-migration">
 
 ## Important Astro 4 Migration Note:
+
 Prior to Astro 4, the Astro UXDS Status Component was responsible for both the [small status indicators](https://astrouxds.com/ui-components/status-symbol) and the more complicated [monitoring icon](https://astrouxds.com/ui-components/icons-and-symbols). Astro 4 seperates these two use cases in to distinct components. The [Astro UXDS Status Component](../rux-status/) is solely responsible for the status indicators. This component, Astro UXDS Monitoring Icon, replaces the previous "Advanced Status" features of Astro UXDS Status.
 
 To upgrade to Astro 4 any instance of `<rux-status>` used as an "Advanced Status" or "Monitoring Icon" should replace `<rux-status>` with `<rux-monitoring-icon>`. For example:

--- a/src/components/rux-notification/README.md
+++ b/src/components/rux-notification/README.md
@@ -24,7 +24,7 @@ npm i --save @astrouxds/rux-notification
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -39,7 +39,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxNotification } from '@astrouxds/rux-notification/rux-notification.js';
+import { RuxNotification } from "@astrouxds/rux-notification/rux-notification.js";
 ```
 
 ### 3. Render the Astro Notification Banner Web Component

--- a/src/components/rux-pop-up-menu/README.md
+++ b/src/components/rux-pop-up-menu/README.md
@@ -16,7 +16,7 @@ npm i --save @astrouxds/rux-pop-up-menu
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -31,7 +31,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxPopUpMenu } from '@astrouxds/rux-pop-up-menu/rux-pop-up-menu.js';
+import { RuxPopUpMenu } from "@astrouxds/rux-pop-up-menu/rux-pop-up-menu.js";
 ```
 
 ### 3. Render the Astro Pop Up Menu Web Component
@@ -41,7 +41,7 @@ Pass properties as attributes of the Astro Pop Up Menu custom element:
 ```xml
 <rux-pop-up-menu
  id="popup-menu-1"
- .onPopUpMenuItemSelected="${_onItemUpdated}" 
+ .onPopUpMenuItemSelected="${_onItemUpdated}"
  .onPopUpMenuExpandedChange="${_onMenuExpanded}"
  .data="${data}">
 </rux-pop-up-menu>
@@ -70,9 +70,9 @@ Extending Astro Pop Up Menu with custom content. Any additional content that is 
 
 ### Properties
 
-| Property | Type   | Default | Required | Description                                                                |
-| -------- | ------ | ------- | -------- | -------------------------------------------------------------------------- |
-| `id`     | String | `-`     | Yes      | A unique identifier to associate the pop up menu with a triggering element |
+| Property | Type   | Default | Required | Description                                                                                                                                          |
+| -------- | ------ | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`     | String | `-`     | Yes      | A unique identifier to associate the pop up menu with a triggering element                                                                           |
 | `data`   | Array  | `-`     | Yes      | An array of objects that defines the pop up menu’s labels. **Note:** when used in an Angular environment you may need to stringify the data property |
 
 ### Sample `data` Array
@@ -114,8 +114,8 @@ Pop Up Menu emits a `pop-up-menu-item-selected` event whenever a user clicks on 
 #### Sample Tree event
 
 ```javascript
-window.addEventListener('pop-up-menu-item-selected', (e) => {
-  console.log('Pop Up Menu Item Selected', e.detail.selected);
+window.addEventListener("pop-up-menu-item-selected", (e) => {
+  console.log("Pop Up Menu Item Selected", e.detail.selected);
 });
 ```
 

--- a/src/components/rux-progress/README.md
+++ b/src/components/rux-progress/README.md
@@ -16,7 +16,7 @@ npm i --save @astrouxds/rux-progress
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -31,7 +31,7 @@ Or, [download Astro Components as a .zip](https://github.com/RocketCommunication
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxProgress } from '@astrouxds/rux-progress/rux-progress.js';
+import { RuxProgress } from "@astrouxds/rux-progress/rux-progress.js";
 ```
 
 ### 3. Render the Astro Template Web Component
@@ -97,6 +97,7 @@ Indeterminate progress
 ## Revision History
 
 ##### **4.0.2**
+
 - fixed broken property `hideLabel`
 
 ##### **4.0**

--- a/src/components/rux-push-button/README.md
+++ b/src/components/rux-push-button/README.md
@@ -18,7 +18,7 @@ npm i --save @astrouxds/rux-push-button
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -33,7 +33,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxPushButton } from '@astrouxds/rux-push-button/rux-push-button.js';
+import { RuxPushButton } from "@astrouxds/rux-push-button/rux-push-button.js";
 ```
 
 ### 3. Render the Astro Push Button Web Component

--- a/src/components/rux-segmented-button/README.md
+++ b/src/components/rux-segmented-button/README.md
@@ -18,7 +18,7 @@ npm i --save @astrouxds/rux-segmented-button
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -33,7 +33,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxSegmentedButton } from '@astrouxds/rux-segmented-button/rux-segmented-button.js';
+import { RuxSegmentedButton } from "@astrouxds/rux-segmented-button/rux-segmented-button.js";
 ```
 
 ### 3. Render the Astro Segmented Button Web Component
@@ -58,41 +58,49 @@ render() {
 
 ### Properties (for the Segmented Button component)
 
-| Property | Type  | Default | Required | Description                                             |
-| -------- | ----- | ------- | -------- | ------------------------------------------------------- |
-| `data`   | Array | `[]`    | Yes      | Items in this Array are the individual button segments. |
-| `selected` | String | —       | No    | When passed in on load, this selects the first button segment with a matching label. When the selected segment changes, this property updates with the currently selected value, which reflects back to the component attribute. If no button segment label matches this string, then no segment is selected. This value takes priority over setting `selected` boolean property on the items in the `data` array. |
-
+| Property   | Type   | Default | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ---------- | ------ | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `data`     | Array  | `[]`    | Yes      | Items in this Array are the individual button segments.                                                                                                                                                                                                                                                                                                                                                            |
+| `selected` | String | —       | No       | When passed in on load, this selects the first button segment with a matching label. When the selected segment changes, this property updates with the currently selected value, which reflects back to the component attribute. If no button segment label matches this string, then no segment is selected. This value takes priority over setting `selected` boolean property on the items in the `data` array. |
 
 ### Sample Astro UXDS Segmented Button `data` Array
 
 ```js
-[{ label: 'First segment' }, { label: 'Second segment' }, { label: 'Third segment' }];
+[
+  { label: "First segment" },
+  { label: "Second segment" },
+  { label: "Third segment" },
+];
 ```
 
 ### Properties for items within the `data` Array
 
-| Property   | Type    | Default | Required | Description |
-| ---------- | ------- | ------- | -------- | ------------------------------------------------------- |
-| `label`    | String  | —       | Yes      | Defines the label for the button segment. |
-| `selected` | Boolean | —       | No       | If true, selects this segment rather than the first segment in the `data` Array on mount. If more than one segment has a truthy `selected` value, the earliest one in the Array will register and the rest are ignored. Note that if the `selected` string property of the parent `rux-segmented-button` takes priority. When the selected segment changes within the component, this property updates with `true` or `false` if selected or not selected, on each segment.|
+| Property   | Type    | Default | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ---------- | ------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `label`    | String  | —       | Yes      | Defines the label for the button segment.                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `selected` | Boolean | —       | No       | If true, selects this segment rather than the first segment in the `data` Array on mount. If more than one segment has a truthy `selected` value, the earliest one in the Array will register and the rest are ignored. Note that if the `selected` string property of the parent `rux-segmented-button` takes priority. When the selected segment changes within the component, this property updates with `true` or `false` if selected or not selected, on each segment. |
 
 ### Events
 
-| Event Name | Description |
-| --- | ---|
-| `change` | Fires when a button segment is changed. Inspect the Event target to find the `data` and `selected` component properties. See [HTMLElement `change` event on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) for more information. |
+| Event Name | Description                                                                                                                                                                                                                                                       |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `change`   | Fires when a button segment is changed. Inspect the Event target to find the `data` and `selected` component properties. See [HTMLElement `change` event on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) for more information. |
 
-```js 
-  document.addEventListener('change', (e) => console.log('Target element:', e.target)); 
-  // > Target element: <rux-segmented-button>
+```js
+document.addEventListener("change", (e) =>
+  console.log("Target element:", e.target)
+);
+// > Target element: <rux-segmented-button>
 
-  document.addEventListener('change', (e) => console.log('Selected Segment:', e.target.selected));
-  // > Selected Segment: Second Segment
+document.addEventListener("change", (e) =>
+  console.log("Selected Segment:", e.target.selected)
+);
+// > Selected Segment: Second Segment
 
-  document.addEventListener('change', (e) => console.log('Array of Segments:', e.target.data));
-  // > Array of Segments: [{ label: "First Segment", selected: false }, { label: "Second Segment", selected: true }, { label: "Third Segment", selected: false }]
-
+document.addEventListener("change", (e) =>
+  console.log("Array of Segments:", e.target.data)
+);
+// > Array of Segments: [{ label: "First Segment", selected: false }, { label: "Second Segment", selected: true }, { label: "Third Segment", selected: false }]
 ```
 
 ---
@@ -141,6 +149,7 @@ Configure the component using native HTML attributes. For each group of radio bu
 ## Revision History
 
 ##### **4.1**
+
 - Exposed `selected` attribute on component to reflect currently selected segment to an attribute on the component
 - Added `change` event to notify document of segment selection change within component
 

--- a/src/components/rux-slider/README.md
+++ b/src/components/rux-slider/README.md
@@ -19,7 +19,7 @@ npm i -save @astrouxds/rux-slider
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -34,7 +34,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxSlider } from '@astrouxds/rux-slider/rux-slider.js';
+import { RuxSlider } from "@astrouxds/rux-slider/rux-slider.js";
 ```
 
 ### 3. Render the Astro Slider Web Component
@@ -69,8 +69,10 @@ Pass properties via attributes similar to the native [HTML Input Range](https://
 | `disabled`   | Boolean | `false` | No       | Sets a disabled state on the component, which prevents typical user action from changing the value.                                                                                                                   |
 
 ## Revision History
+
 ##### **5.0**
- - Removed fallback CSS properties
+
+- Removed fallback CSS properties
 
 ##### **4.0**
 

--- a/src/components/rux-status/README.md
+++ b/src/components/rux-status/README.md
@@ -18,7 +18,7 @@ npm i --save @astrouxds/rux-status
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -33,7 +33,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxStatus } from '@astrouxds/rux-status/rux-status.js';
+import { RuxStatus } from "@astrouxds/rux-status/rux-status.js";
 ```
 
 ### 3. Render the Astro Status Web Component
@@ -108,4 +108,5 @@ Astro CSS classes follow the [BEM-style](http://getbem.com/introduction/) naming
 <a name="astro-4-migration">
 
 ## Important Astro 4 Migration Note:
+
 Prior to Astro 4, the Astro UXDS Status Component was responsible for both the [small status indicators](https://astrouxds.com/ui-components/status-symbol) and the more complicated [monitoring icon](https://astrouxds.com/ui-components/icons-and-symbols). Astro 4 separates these two use cases into distinct components. The Astro UXDS Status Component is solely responsible for the status indicators. This component, [Astro UXDS Monitoring Icon Component](../rux-monitoring-icon/), replaces the previous "Advanced Status" features of Astro UXDS Status.

--- a/src/components/rux-tabs/README.md
+++ b/src/components/rux-tabs/README.md
@@ -18,7 +18,7 @@ npm i --save @astrouxds/rux-tabs
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro UXDS Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -33,7 +33,7 @@ Or, [download the Astro UXDS Components as a .zip](https://github.com/RocketComm
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxTabs } from '@astrouxds/rux-tabs/rux-tabs.js';
+import { RuxTabs } from "@astrouxds/rux-tabs/rux-tabs.js";
 ```
 
 ### 3. Render the Astro Tabs Web Component

--- a/src/components/rux-tree/README.md
+++ b/src/components/rux-tree/README.md
@@ -20,7 +20,7 @@ npm i --save @astrouxds/rux-tree
 
 You may use Yarn, NPM, or your Node package manager of choice. The `--save` flag adds this component as a dependency in your `package.json` file.
 
-#### **Alternatively**, download the [Astro Component Library](https://github.com/RocketCommunicationsInc/astro-components/src/master/) source to your project.
+#### **Alternatively**, download the [Astro Component Library](https://github.com/RocketCommunicationsInc/astro-components/) source to your project.
 
 Via CLI:
 
@@ -35,7 +35,7 @@ Or, [download Astro Components as a .zip](https://github.com/RocketCommunication
 This example assumes you're using the NPM package in `node_modules`. Otherwise, import the component using the path to the Astro Components directory in your project.
 
 ```javascript
-import { RuxTree } from '@astrouxds/rux-tree/rux-tree.js';
+import { RuxTree } from "@astrouxds/rux-tree/rux-tree.js";
 ```
 
 ### 3. Render the Astro Tree Web Component
@@ -48,7 +48,7 @@ import { RuxTree } from '@astrouxds/rux-tree/rux-tree.js';
 
 | Property | Type  | Default | Required | Description                                                                 |
 | -------- | ----- | ------- | -------- | --------------------------------------------------------------------------- |
-| `data`   | Array | `[]`     | yes      | An array of objects defining the tree structure. See a sample object below. |
+| `data`   | Array | `[]`    | yes      | An array of objects defining the tree structure. See a sample object below. |
 
 #### Sample `data` object
 
@@ -78,14 +78,14 @@ import { RuxTree } from '@astrouxds/rux-tree/rux-tree.js';
 
 ### Object Properties
 
-| Property   | Type   | Required | Description                                                                                                                                 |
-| ---------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `label`    | String | yes      | The label for the tree item                                                                                                                 |
-| `id`       | String | no       | An optional property to help identify individual tree elements                                                                              |
-| `selected` | Boolean | no      | If set to `true`, this item shows a selected style. When a new item is selected by user click, all other selected items are unselected. |
-| `expanded` | Boolean | no      | If set to `true`, this item is expanded. Multiple items can be expanded at the same time. |
-| `status`   | String | no       | An optional property to assign status. See [Astro Status](http://www.astrouxds.com/library/tree) for valid status options                   |
-| `children` | Array  | no       | An array of child elements. Children use the same structure as parents and may include their own `children` array to create nested elements |
+| Property   | Type    | Required | Description                                                                                                                                 |
+| ---------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `label`    | String  | yes      | The label for the tree item                                                                                                                 |
+| `id`       | String  | no       | An optional property to help identify individual tree elements                                                                              |
+| `selected` | Boolean | no       | If set to `true`, this item shows a selected style. When a new item is selected by user click, all other selected items are unselected.     |
+| `expanded` | Boolean | no       | If set to `true`, this item is expanded. Multiple items can be expanded at the same time.                                                   |
+| `status`   | String  | no       | An optional property to assign status. See [Astro Status](http://www.astrouxds.com/library/tree) for valid status options                   |
+| `children` | Array   | no       | An array of child elements. Children use the same structure as parents and may include their own `children` array to create nested elements |
 
 ### Component Events
 
@@ -94,12 +94,12 @@ Tree emits a `tree-updated` event whenever the selected tree item changes. Event
 #### Sample Tree event
 
 ```javascript
-window.addEventListener('tree-updated', (event) => {
+window.addEventListener("tree-updated", (event) => {
   // an array that reflects the current state of the tree
-  console.log('Tree data', event.detail.data);
+  console.log("Tree data", event.detail.data);
 
   // an object representing the currently selected tree item
-  console.log('Selected tree item', event.detail.selected);
+  console.log("Selected tree item", event.detail.selected);
 });
 ```
 


### PR DESCRIPTION
The link to the component library in the readme template and subsequently all component readme files was https://github.com/RocketCommunicationsInc/astro-components/src/master/ which lead to a 404 error. This fix updates that link to https://github.com/RocketCommunicationsInc/astro-components/