### PR TITLE
fix(rux-button): keep base font size on small/large variants

### DIFF
--- a/src/components/rux-button/rux-button.js
+++ b/src/components/rux-button/rux-button.js
@@ -160,14 +160,12 @@ export class RuxButton extends LitElement {
         */
 
                 .rux-button--small {
-                    font-size: var(--smallLabelFontSize);
                     height: 1.625rem;
                     padding: 0 1rem;
                     line-height: 1;
                 }
 
                 .rux-button--large {
-                    font-size: var(--largeLabelFontSize);
                     height: 2.875rem;
                     min-width: 3rem;
                     padding: 0 1rem;


### PR DESCRIPTION
## Brief Description

Button Small variant should not change font size
Button Large variant should not change font size

## JIRA Link

[ASTRO-1570](https://rocketcom.atlassian.net/browse/ASTRO-1570)

## Motivation and Context

Design -> Dev discrepancy that came up during Figma review.

## Types of changes

-   [x] Bug fix
