### PR TITLE
fix(clock): day of year uses clock tz

### DIFF
--- a/src/components/rux-clock/rux-clock.js
+++ b/src/components/rux-clock/rux-clock.js
@@ -85,7 +85,7 @@ export class RuxClock extends LitElement {
             { timeZone: this._timezone }
         )
         this.dayOfYear = getDayOfYear(
-            zonedTimeToUtc(new Date(), this._timezone)
+            utcToZonedTime(new Date(), this._timezone)
         )
     }
 


### PR DESCRIPTION
Fixes an issue where the day of year was incorrectly changing based off the user's timezone and not the timezone of the clock

Backported from https://github.com/RocketCommunicationsInc/astro/pull/139/files

[ASTRO-2512](https://rocketcom.atlassian.net/browse/ASTRO-2512)