### PR TITLE
fix(clock): julien date is now always 3 digits

### DIFF
--- a/src/components/rux-clock/rux-clock.js
+++ b/src/components/rux-clock/rux-clock.js
@@ -186,7 +186,7 @@ export class RuxClock extends LitElement {
                               class="rux-clock__segment__value"
                               aria-labelledby="rux-clock__day-of-year-label"
                           >
-                              ${this.dayOfYear}
+                              ${this.dayOfYear.toString().padStart(3, '0')}
                           </div>
                           <div
                               class="rux-clock__segment__label"


### PR DESCRIPTION
Updates `${this.dayOfYear}` to `${this.dayOfYear.toString().padStart(3, '0')}` to ensure that the date is always 3 digits with leading zero's if necessary. 

Issue: https://github.com/RocketCommunicationsInc/astro-components/issues/186