### PR TITLE
set default color on color property

### DIFF
--- a/src/components/rux-icon/rux-icon.js
+++ b/src/components/rux-icon/rux-icon.js
@@ -40,6 +40,7 @@ export class RuxIcon extends LitElement {
         /* TODO: a non-presumptive way to assign a better default label if the user doesn’t provide one */
         this.label = 'icon'
         this.viewBox = '0 0 24 24'
+        this.color = 'var(--iconDefaultColor)'
     }
 
     firstUpdated() {


### PR DESCRIPTION
having color not set in constructor forces it to be set to undefined in inline styles which sets icon color css variable to undefined